### PR TITLE
Fix typo in usage example

### DIFF
--- a/share/gem_home/gem_home.sh
+++ b/share/gem_home/gem_home.sh
@@ -58,7 +58,7 @@ Examples:
 
 	$ gem_home path/to/project
 	$ gem_home -
-	$ gem_home --vendor
+	$ gem_home --version
 
 USAGE
 			;;


### PR DESCRIPTION
There's no "--vendor" option, so I'm guessing this example was intended to use "--version".