### PR TITLE
Respect DESTDIR upon make (un)install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,14 +67,14 @@ rpm:
 	rpmbuild -ba rpm/chruby.spec
 
 install:
-	for dir in $(INSTALL_DIRS); do mkdir -p $(PREFIX)/$$dir; done
-	for file in $(INSTALL_FILES); do cp $$file $(PREFIX)/$$file; done
-	mkdir -p $(DOC_DIR)
-	cp -r $(DOC_FILES) $(DOC_DIR)/
+	for dir in $(INSTALL_DIRS); do mkdir -p $(DESTDIR)$(PREFIX)/$$dir; done
+	for file in $(INSTALL_FILES); do cp $$file $(DESTDIR)$(PREFIX)/$$file; done
+	mkdir -p $(DESTDIR)$(DOC_DIR)
+	cp -r $(DOC_FILES) $(DESTDIR)$(DOC_DIR)/
 
 uninstall:
-	for file in $(INSTALL_FILES); do rm -f $(PREFIX)/$$file; done
-	rm -rf $(DOC_DIR)
-	rmdir $(SHARE_DIR)
+	for file in $(INSTALL_FILES); do rm -f $(DESTDIR)$(PREFIX)/$$file; done
+	rm -rf $(DESTDIR)$(DOC_DIR)
+	rmdir $(DESTDIR)$(SHARE_DIR)
 
 .PHONY: build download sign verify clean check test tag release rpm install uninstall all


### PR DESCRIPTION
Gentoo/Funtoo portages are passing DESTDIR where files should be
installed prior merging them to system. chruby and ruby-install
are respecting that variable, so would be nice if this will be
merged.