### PR TITLE
Tests should not fail on existing GEM_HOME/GEM_PATH env variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,10 @@ check:
 	shellcheck share/$(NAME)/*.sh
 
 test:
-	SHELL=`command -v bash` ./test/runner
 	SHELL=`command -v zsh`  ./test/runner
+	SHELL=`command -v bash` ./test/runner
+	SHELL=`command -v bash` GEM_HOME= GEM_PATH= ./test/runner
+	SHELL=`command -v bash` GEM_HOME=/usr/gems GEM_PATH=/usr/gems:/sys/gems PATH=/usr/gems/bin:/sys/gems/bin:$(PATH) ./test/runner
 
 tag:
 	git push origin master

--- a/test/helper.sh
+++ b/test/helper.sh
@@ -5,8 +5,12 @@ export PREFIX="$PWD/test"
 export HOME="$PREFIX/home"
 export PATH="$PWD/bin:$PATH"
 
-#export GEM_HOME="$HOME/.gem/ruby/2.1.2"
-#export GEM_PATH="$HOME/.gem/ruby/2.1.2:/opt/rubies/ruby-2.1.2/lib/ruby/gems/2.1.0"
+if [[ -z "${GEM_PATH}" && -n "${GEM_HOME}" ]] || [[ -n "${GEM_PATH}" && -z "${GEM_HOME}" ]]; then
+    printf \
+        '\n\033[1;31m!!! WARN\033[0m\n\033[1;31m!!! \033[0m\033[1m%s\033[0m\n\033[1;31m!!! \033[0m\033[1m%s\033[0m\n\n' \
+        'Prior to running tests, either unset the GEM_PATH and GEM_HOME variables OR set them both!' \
+        'Ignoring this and using a combination of these variables set and unset will cause issues...'
+fi
 
 eval "$(ruby - <<EOF
 puts "test_ruby_engine=#{defined?(RUBY_ENGINE) ? RUBY_ENGINE : 'ruby'};"

--- a/test/push_test.sh
+++ b/test/push_test.sh
@@ -11,7 +11,7 @@ function test_gem_home_push()
 	assertEquals "did not set \$GEM_HOME correctly" "$expected_gem_dir" \
 		                                        "$GEM_HOME"
 
-	assertEquals "did not prepend to \$GEM_PATH" "$expected_gem_dir" \
+    assertEquals "did not prepend to \$GEM_PATH" "$expected_gem_dir${original_gem_path:+:}${original_gem_path:-}" \
 		                                     "$GEM_PATH"
 
 	assertEquals "did not prepend the new gem bin/ dir to \$PATH" \
@@ -51,7 +51,7 @@ function test_gem_home_push_twice()
 		     "$GEM_HOME"
 
 	assertEquals "did not prepend both gem dirs to \$GEM_PATH" \
-		     "$expected_gem_dir2:$expected_gem_dir1" \
+		     "$expected_gem_dir2:$expected_gem_dir1${original_gem_path:+:}${original_gem_path:-}" \
 		     "$GEM_PATH"
 
 	assertEquals "did not inject the new gem bin/ into \$PATH" \


### PR DESCRIPTION
I changed the push/pop tests to account for the possibility that `GEM_HOME` and `GEM_PATH` may be set already in the environment where the tests are being run. Prior, the tests would fail when any values were assigned to the `GEM_*` variables.

A warning was also added for the unsupported state of having a random combination of the `GEM_*` variables set and unset: either they must both be assigned a value or neither should be assigned a value, otherwise the tests break. The addition of a large warning makes this clear.